### PR TITLE
UHF-2303: Navigation block level change

### DIFF
--- a/conf/cmi/block.block.mainnavigation.yml
+++ b/conf/cmi/block.block.mainnavigation.yml
@@ -25,7 +25,7 @@ settings:
     views: views
     menu_link_content: menu_link_content
     default: '0'
-  level: 1
+  level: 2
   depth: 2
   expand_all_items: true
 visibility: {  }


### PR DESCRIPTION
How to test:

1. Checkout this branch: `git fetch && git checkout UHF-2303_navigation_block_level_change`
2. Run `make drush-cim && make drush-cr`
3. Go to the site and make sure your main menu structure is similar to what the real menu tree will be like but no need to copy the whole tree:
Strategia ja talous (landing page)
----> Kaupunkistrategia (basic page)
----> Kestävä kehitys (basic page)
----> etc. 
4. Go to Strategia ja talous landing page and you should see on the main menu the "Kaupunkistrategia" and "Kestävä kehitys" basic pages.
5. Go to either of the basic pages and the menu on the left should make sense as well (no settings changed here tho).