### PR TITLE
UHF-2828: Siteimprove config & helfi_linkedevents removed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "drupal/helfi_ahjo": "^1.0",
         "drupal/helfi_azure_fs": "^1.0",
         "drupal/helfi_hauki": "^1.0",
-        "drupal/helfi_linkedevents": "^1.0",
         "drupal/helfi_platform_config": "^2.0",
         "drupal/helfi_proxy": "^1.0",
         "drupal/helfi_tpr": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f0f6d5fb0ec12f4a8278c527f84381b",
+    "content-hash": "2b827dc95a6550ee826f2a0ddba7f9e3",
     "packages": [
         {
             "name": "City-of-Helsinki/php-hauki-client",
@@ -4016,40 +4016,6 @@
             "time": "2021-05-21T06:10:50+00:00"
         },
         {
-            "name": "drupal/helfi_linkedevents",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-linkedevents.git",
-                "reference": "11388a54ebb15db7d73fad10ec950a43dd7c180a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-linkedevents/zipball/11388a54ebb15db7d73fad10ec950a43dd7c180a",
-                "reference": "11388a54ebb15db7d73fad10ec950a43dd7c180a",
-                "shasum": ""
-            },
-            "require": {
-                "drupal/helfi_api_base": "*",
-                "drupal/key_value_field": "^1.0",
-                "ext-json": "*"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "drupal/coder": "^8.3"
-            },
-            "type": "drupal-custom-module",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Linked Events integration",
-            "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-linkedevents/tree/1.0.1",
-                "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-linkedevents/issues"
-            },
-            "time": "2021-04-12T07:24:21+00:00"
-        },
-        {
             "name": "drupal/helfi_media_formtool",
             "version": "dev-main",
             "source": {
@@ -4117,16 +4083,16 @@
         },
         {
             "name": "drupal/helfi_platform_config",
-            "version": "2.0.17",
+            "version": "2.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config.git",
-                "reference": "81d53790da4dcd7f29adf72f1fd9f28019b97f47"
+                "reference": "cfdd1eb0bed0af4c64cf572543686ed139cc6e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/81d53790da4dcd7f29adf72f1fd9f28019b97f47",
-                "reference": "81d53790da4dcd7f29adf72f1fd9f28019b97f47",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/cfdd1eb0bed0af4c64cf572543686ed139cc6e49",
+                "reference": "cfdd1eb0bed0af4c64cf572543686ed139cc6e49",
                 "shasum": ""
             },
             "require": {
@@ -4206,10 +4172,10 @@
             ],
             "description": "HELfi platform config",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/latest",
+                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.0.18",
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
-            "time": "2021-10-14T14:53:48+00:00"
+            "time": "2021-10-18T06:01:11+00:00"
         },
         {
             "name": "drupal/helfi_proxy",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -50,6 +50,7 @@ module:
   helfi_media_map_config: 0
   helfi_platform_config: 0
   helfi_proxy: 0
+  helfi_siteimprove_config: 0
   helfi_tpr: 0
   helfi_tpr_config: 0
   helfi_tunnistamo: 0
@@ -100,6 +101,7 @@ module:
   select2_icon: 0
   serialization: 0
   simple_sitemap: 0
+  siteimprove: 0
   social_media: 0
   syslog: 0
   system: 0

--- a/conf/cmi/siteimprove.domain.single.settings.yml
+++ b/conf/cmi/siteimprove.domain.single.settings.yml
@@ -1,0 +1,3 @@
+domain: ''
+_core:
+  default_config_hash: LwImylUTdzscxHfVmILtYqYn7gdXYdNMhWwzpzTwTbU

--- a/conf/cmi/siteimprove.settings.yml
+++ b/conf/cmi/siteimprove.settings.yml
@@ -2,7 +2,7 @@ token: 6a9fe80dbd8c46eda4518b69f4787f6a
 _core:
   default_config_hash: t5W6QbLZA8s7VAoHDDldhRB2Emm1blOGOOKHMV855Gk
 domain_plugin_id: siteimprovedomain_simple
-prepublish_enabled: false
+prepublish_enabled: true
 api_username: ''
 api_key: ''
 enabled_content_types: {  }

--- a/conf/cmi/siteimprove.settings.yml
+++ b/conf/cmi/siteimprove.settings.yml
@@ -1,0 +1,9 @@
+token: 6a9fe80dbd8c46eda4518b69f4787f6a
+_core:
+  default_config_hash: t5W6QbLZA8s7VAoHDDldhRB2Emm1blOGOOKHMV855Gk
+domain_plugin_id: siteimprovedomain_simple
+prepublish_enabled: false
+api_username: ''
+api_key: ''
+enabled_content_types: {  }
+enabled_taxonomies: {  }

--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -149,3 +149,6 @@ permissions:
   - 'administer matomo'
   - 'administer matomo reports'
   - 'use php for matomo tracking visibility'
+  - 'use siteimprove'
+  - 'administer siteimprove'
+  - 'use siteimprove prepublish'

--- a/conf/cmi/user.role.content_producer.yml
+++ b/conf/cmi/user.role.content_producer.yml
@@ -65,3 +65,5 @@ permissions:
   - 'view scheduled content'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'use siteimprove'
+  - 'use siteimprove prepublish'

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -48,6 +48,10 @@ if (isset($_SERVER['WODBY_APP_NAME'])) {
 
 $config['openid_connect.client.tunnistamo']['settings']['client_id'] = getenv('TUNNISTAMO_CLIENT_ID');
 $config['openid_connect.client.tunnistamo']['settings']['client_secret'] = getenv('TUNNISTAMO_CLIENT_SECRET');
+
+$config['siteimprove.settings']['api_username'] = getenv('SITEIMPROVE_API_USERNAME');
+$config['siteimprove.settings']['api_key'] = getenv('SITEIMPROVE_API_KEY');
+
 // Drupal route(s).
 $routes = (getenv('DRUPAL_ROUTES')) ? explode(',', getenv('DRUPAL_ROUTES')) : [];
 


### PR DESCRIPTION
How to test:

- Install Strategia instance
- Checkout this branch: `git checkout UHF-2828_siteimprove_config`
- Import config: `make drush-cim`
- Log in as admin and make sure that
  - `helfi_siteimprove_config` and `siteimprove` modules are enabled
  - Siteimprove module has configuration in place
  - Permissions for admin and content producer roles are as in their respective yml´s 