### PR TITLE
UHF-2938: Add image paragraph to accordion item

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3826,16 +3826,16 @@
         },
         {
             "name": "drupal/hdbt",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-hdbt.git",
-                "reference": "bd6bbd1350c7077a025f5e744401004b04025c50"
+                "reference": "b00769d6d0413bb60b044527f2b18da38dbdd7b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/bd6bbd1350c7077a025f5e744401004b04025c50",
-                "reference": "bd6bbd1350c7077a025f5e744401004b04025c50",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/b00769d6d0413bb60b044527f2b18da38dbdd7b2",
+                "reference": "b00769d6d0413bb60b044527f2b18da38dbdd7b2",
                 "shasum": ""
             },
             "require": {
@@ -3850,10 +3850,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/2.0.1",
+                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/2.0.3",
                 "issues": "https://github.com/City-of-Helsinki/drupal-hdbt/issues"
             },
-            "time": "2021-11-08T15:41:22+00:00"
+            "time": "2021-11-11T10:17:34+00:00"
         },
         {
             "name": "drupal/hdbt_admin",
@@ -4089,16 +4089,16 @@
         },
         {
             "name": "drupal/helfi_platform_config",
-            "version": "2.0.32",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config.git",
-                "reference": "7f08f64ad8f60eb56d80784f5d9f21c099e4ce50"
+                "reference": "8d93b937792bb21514832c7316be401620ca143c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/7f08f64ad8f60eb56d80784f5d9f21c099e4ce50",
-                "reference": "7f08f64ad8f60eb56d80784f5d9f21c099e4ce50",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/8d93b937792bb21514832c7316be401620ca143c",
+                "reference": "8d93b937792bb21514832c7316be401620ca143c",
                 "shasum": ""
             },
             "require": {
@@ -4160,7 +4160,8 @@
                         "https://www.drupal.org/project/default_content/issues/2698425#comment-13809863": "https://www.drupal.org/files/issues/2020-09-02/default_content-integrity_constrait_violation-3162987-2.patch"
                     },
                     "drupal/eu_cookie_compliance": {
-                        "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://gist.githubusercontent.com/khalima/25c1972340725bc57ac088b268c5736a/raw/a5dd1a39b2e3da23105c4aa5bfa9fd8c2373eb6f/eu_cookie_compliance_block_8.x-1.19.patch"
+                        "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/d1a6866b2138f7d3597df79f395a5c1a9e19ee2e/patches/eu_cookie_compliance_block_8.x-1.19.patch",
+                        "[#UHF-2956] Fix JavaScript error at cookie preference page": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/97683d32e57808a4c9a4f6a2d20757af7a0b8c37/patches/eu_cookie_compliance_js_error_8.x-1.19-patched.patch"
                     },
                     "drupal/features": {
                         "https://www.drupal.org/project/features/issues/2869336": "https://www.drupal.org/files/issues/features_export-config-translation-2869336-2.patch"
@@ -4181,10 +4182,10 @@
             ],
             "description": "HELfi platform config",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/latest",
+                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.1.2",
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
-            "time": "2021-11-08T15:18:09+00:00"
+            "time": "2021-11-11T10:01:11+00:00"
         },
         {
             "name": "drupal/helfi_proxy",
@@ -4228,16 +4229,16 @@
         },
         {
             "name": "drupal/helfi_tpr",
-            "version": "1.5.3",
+            "version": "1.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr.git",
-                "reference": "6c31f9d5af00ec22dd79deb9c260937f18af5864"
+                "reference": "7de84c7e19acd47541c774eb5be30435c404205c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tpr/zipball/6c31f9d5af00ec22dd79deb9c260937f18af5864",
-                "reference": "6c31f9d5af00ec22dd79deb9c260937f18af5864",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tpr/zipball/7de84c7e19acd47541c774eb5be30435c404205c",
+                "reference": "7de84c7e19acd47541c774eb5be30435c404205c",
                 "shasum": ""
             },
             "require": {
@@ -4259,10 +4260,10 @@
             ],
             "description": "TPR integration",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/tree/1.5.3",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/tree/1.5.5",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/issues"
             },
-            "time": "2021-10-29T07:19:32+00:00"
+            "time": "2021-11-10T11:23:09+00:00"
         },
         {
             "name": "drupal/helfi_tunnistamo",
@@ -13453,16 +13454,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.1.11",
+            "version": "2.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "ddc81bb4718747cc93330ccf832e6be8a6c1d015"
+                "reference": "6e3c2b122e0ec41a7e885fcaf19fa15e2e0819a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/ddc81bb4718747cc93330ccf832e6be8a6c1d015",
-                "reference": "ddc81bb4718747cc93330ccf832e6be8a6c1d015",
+                "url": "https://api.github.com/repos/composer/composer/zipball/6e3c2b122e0ec41a7e885fcaf19fa15e2e0819a0",
+                "reference": "6e3c2b122e0ec41a7e885fcaf19fa15e2e0819a0",
                 "shasum": ""
             },
             "require": {
@@ -13531,7 +13532,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.1.11"
+                "source": "https://github.com/composer/composer/tree/2.1.12"
             },
             "funding": [
                 {
@@ -13547,7 +13548,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-02T11:10:26+00:00"
+            "time": "2021-11-09T15:02:04+00:00"
         },
         {
             "name": "composer/metadata-minifier",

--- a/conf/cmi/field.field.paragraph.accordion_item.field_accordion_item_content.yml
+++ b/conf/cmi/field.field.paragraph.accordion_item.field_accordion_item_content.yml
@@ -28,6 +28,7 @@ settings:
     target_bundles:
       columns: columns
       text: text
+      image: image
     target_bundles_drag_drop:
       accordion:
         weight: 12
@@ -35,9 +36,21 @@ settings:
       accordion_item:
         weight: 13
         enabled: false
+      banner:
+        enabled: false
+        weight: 23
       columns:
         enabled: true
         weight: 14
+      content_cards:
+        enabled: false
+        weight: 25
+      content_liftup:
+        enabled: false
+        weight: 26
+      from_library:
+        enabled: false
+        weight: 27
       gallery:
         weight: 15
         enabled: false
@@ -49,17 +62,33 @@ settings:
         enabled: false
       image:
         weight: 18
+        enabled: true
+      liftup_with_image:
         enabled: false
-      link:
-        weight: 19
-        enabled: false
+        weight: 32
+      link: {  }
       list_of_links:
         weight: 20
         enabled: false
       list_of_links_item:
         weight: 21
         enabled: false
+      map:
+        enabled: false
+        weight: 35
+      remote_video:
+        enabled: false
+        weight: 36
+      service_list:
+        enabled: false
+        weight: 37
+      sidebar_text:
+        enabled: false
+        weight: 38
       text:
         enabled: true
         weight: 22
+      unit_search:
+        enabled: false
+        weight: 40
 field_type: entity_reference_revisions


### PR DESCRIPTION
How to test:

1. Checkout this branch.
2. On the root of the instance run `make drush-cr` `make drush-cim` `make drush-cr`
3. Go to edit any content that has accordion or add some. The accordion should now have image paragraph as option as well. Add some images to the paragraph and make sure the paragraph looks good.

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/210
https://github.com/City-of-Helsinki/drupal-hdbt/pull/186
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/193
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/221