### PR TITLE
UHF-4252: Change front page to point to /front-path

### DIFF
--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /node/12
+  front: /front
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en


### PR DESCRIPTION
How to test:

1. Checkout this branch and run `make drush-cim && make drush-cr`
2. Now you should have your frontpage set as /front path. Depending on if you have added a redirect from /front path to some node it should take you there.
3. Test all the environments that they have the /front path redirected to correct place:
https://nginx-strategia-talous-test.agw.arodevtest.hel.fi/en/test-decision-making/front
https://nginx-strategia-talous-dev.agw.arodevtest.hel.fi/en/dev-decision-making/front
https://hallinto.stage.hel.ninja/fi/staging-paatoksenteko-ja-hallinto/front
https://hel.fi/fi/paatoksenteko-ja-hallinto/front 