### PR TITLE
UHF-4778: Genesys chat for Neuvonta

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4200,16 +4200,16 @@
         },
         {
             "name": "drupal/helfi_platform_config",
-            "version": "2.6.2",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config.git",
-                "reference": "fff0cd6ba0dad2c1b458e4d32a5b10bfe5ae3285"
+                "reference": "575127737f98036c52195efebc9e411db0212a3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/fff0cd6ba0dad2c1b458e4d32a5b10bfe5ae3285",
-                "reference": "fff0cd6ba0dad2c1b458e4d32a5b10bfe5ae3285",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/575127737f98036c52195efebc9e411db0212a3c",
+                "reference": "575127737f98036c52195efebc9e411db0212a3c",
                 "shasum": ""
             },
             "require": {
@@ -4308,10 +4308,10 @@
             ],
             "description": "HELfi platform config",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.6.2",
+                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.6.3",
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
-            "time": "2022-03-23T08:59:26+00:00"
+            "time": "2022-03-24T13:21:33+00:00"
         },
         {
             "name": "drupal/helfi_proxy",

--- a/conf/cmi/block.block.genesyschatneuvonta.yml
+++ b/conf/cmi/block.block.genesyschatneuvonta.yml
@@ -1,0 +1,25 @@
+uuid: 05865586-1549-49cb-beae-ffce86d8811a
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_platform_config
+    - system
+  theme:
+    - hdbt
+id: genesyschatneuvonta
+theme: hdbt
+region: attachments
+weight: 0
+provider: null
+plugin: genesys_neuvonta
+settings:
+  id: genesys_neuvonta
+  label: 'Genesys Chat (Neuvonta)'
+  label_display: '0'
+  provider: helfi_platform_config
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: "/neuvonta-ja-tuki/helsinki-info\r\n/informationstjanster-och-stod/helsingfors-info\r\n/advisory-and-support-services/helsinki-info\r\n/neuvonta-ja-tuki/helsinki-info/*\r\n/informationstjanster-och-stod/helsingfors-info/*\r\n/advisory-and-support-services/helsinki-info/*"


### PR DESCRIPTION
How to test:

- install strategia instance
- get this branch: `git checkout UHF-4778_genesys_neuvonta`
- import config: `make drush-cim`
- run `composer install` to get the correct version of the platform config module
- create a page with URL alias that matches the pattern in the block config, for example `/neuvonta-ja-tuki/helsinki-info`
- go to the page and see the chat appear in the lower right corner
- **optionally**, create the other language versions of the page and see the chat has the correct language
  - sv URL alias: `/informationstjanster-och-stod/helsingfors-info`
  - en URL alias: `/advisory-and-support-services/helsinki-info`