### PR TITLE
UHF-6315: Genesys chat visibility

### DIFF
--- a/conf/cmi/block.block.genesyschatneuvonta.yml
+++ b/conf/cmi/block.block.genesyschatneuvonta.yml
@@ -22,4 +22,4 @@ visibility:
   request_path:
     id: request_path
     negate: false
-    pages: "/neuvonta-ja-tuki/helsinki-info\r\n/informationstjanster-och-stod/helsingfors-info\r\n/advisory-and-support-services/helsinki-info\r\n/neuvonta-ja-tuki/helsinki-info/*\r\n/informationstjanster-och-stod/helsingfors-info/*\r\n/advisory-and-support-services/helsinki-info/*"
+    pages: "/neuvonta-ja-tuki/helsinki-info\r\n/informationstjanster-och-stod/helsingfors-info\r\n/advisory-and-support-services/helsinki-info\r\n/neuvonta-ja-tuki/helsinki-info/*\r\n/informationstjanster-och-stod/helsingfors-info/*\r\n/advisory-and-support-services/helsinki-info/*\r\n/ota-yhteytta/helsinki-info\r\n/ta-kontakt/helsingfors-info\r\n/contact-us/helsinki-info"


### PR DESCRIPTION
# [UHF-6315](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6315)

Genesys chat was missing on some pages.

## What was done
- Genesys chat was added on some pages where it was missing from

## How to install
1. Set up STRATEGIA instance
2. Get this branch: `git checkout UHF-6315_genesys_visibility`
3. Import config: `make drush-cim`
4. Clear cache: `make drush-cr`

## How to test
- Navigate to the following paths
  - /ota-yhteytta/helsinki-info
  - /ta-kontakt/helsingfors-info
  - /contact-us/helsinki-info

and check that the Genesys chat is visible on those pages.

* [x] Check that this feature works
* [x] Check that code follows our standards

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
