### PR TITLE
UHF-6325: Chat leijuke

### DIFF
--- a/conf/cmi/block.block.chatleijuke.yml
+++ b/conf/cmi/block.block.chatleijuke.yml
@@ -1,5 +1,5 @@
 uuid: c1580372-3c2f-49ea-b3cb-118588cc4df0
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:
@@ -18,7 +18,7 @@ settings:
   label: 'Chat Leijuke Neuvonta'
   label_display: '0'
   provider: helfi_platform_config
-  chat_title: 'Kysy kaupungista!'
+  chat_title: 'Ask about the city!'
   chat_selection: genesys_neuvonta
 visibility:
   request_path:

--- a/conf/cmi/block.block.chatleijuke.yml
+++ b/conf/cmi/block.block.chatleijuke.yml
@@ -1,5 +1,5 @@
 uuid: c1580372-3c2f-49ea-b3cb-118588cc4df0
-langcode: en
+langcode: fi
 status: true
 dependencies:
   module:

--- a/conf/cmi/block.block.chatleijuke.yml
+++ b/conf/cmi/block.block.chatleijuke.yml
@@ -1,5 +1,5 @@
-uuid: 05865586-1549-49cb-beae-ffce86d8811a
-langcode: en
+uuid: c1580372-3c2f-49ea-b3cb-118588cc4df0
+langcode: fi
 status: true
 dependencies:
   module:
@@ -7,17 +7,19 @@ dependencies:
     - system
   theme:
     - hdbt
-id: genesyschatneuvonta
+id: chatleijuke
 theme: hdbt
 region: attachments
 weight: 0
 provider: null
-plugin: genesys_neuvonta
+plugin: chat_leijuke
 settings:
-  id: genesys_neuvonta
-  label: 'Genesys Chat (Neuvonta)'
+  id: chat_leijuke
+  label: 'Chat Leijuke Neuvonta'
   label_display: '0'
   provider: helfi_platform_config
+  chat_title: 'Kysy kaupungista!'
+  chat_selection: genesys_neuvonta
 visibility:
   request_path:
     id: request_path

--- a/conf/cmi/block.block.chatleijuke.yml
+++ b/conf/cmi/block.block.chatleijuke.yml
@@ -1,5 +1,5 @@
 uuid: c1580372-3c2f-49ea-b3cb-118588cc4df0
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:

--- a/conf/cmi/language/en/block.block.chatleijuke.yml
+++ b/conf/cmi/language/en/block.block.chatleijuke.yml
@@ -1,0 +1,2 @@
+settings:
+  chat_title: 'Ask about the city!'

--- a/conf/cmi/language/en/block.block.chatleijuke.yml
+++ b/conf/cmi/language/en/block.block.chatleijuke.yml
@@ -1,2 +1,0 @@
-settings:
-  chat_title: 'Ask about the city!'

--- a/conf/cmi/language/fi/block.block.chatleijuke.yml
+++ b/conf/cmi/language/fi/block.block.chatleijuke.yml
@@ -1,0 +1,2 @@
+settings:
+  chat_title: 'Kysy kaupungista!'

--- a/conf/cmi/language/sv/block.block.chatleijuke.yml
+++ b/conf/cmi/language/sv/block.block.chatleijuke.yml
@@ -1,0 +1,2 @@
+settings:
+  chat_title: 'Fråga staden!'


### PR DESCRIPTION
# [UHF-6325](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6325)
<!-- What problem does this solve? -->
Replaces chat block with leijuke.
## What was done
<!-- Describe what was done -->

* Replaced chat block with leijuke block.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6325-chat-via-leijuke`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works by visiting the below pages and interacting with the chat leijuke:
 - /neuvonta-ja-tuki/helsinki-info
 - /informationstjanster-och-stod/helsingfors-info
 - /advisory-and-support-services/helsinki-info
(you may need to manually add the pages to test)

* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* [SOTE leijuke](https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/430)
* [KYMP leijuke](https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/460)
