### PR TITLE
UHF-6829: Updated hdbt to deploy dropdown indicator fix.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4053,16 +4053,16 @@
         },
         {
             "name": "drupal/hdbt",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-hdbt.git",
-                "reference": "bd60fbb12c456415a344e041e82161070a8e5188"
+                "reference": "5ef9f68ec6854d001dc37a08feed28297357673b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/bd60fbb12c456415a344e041e82161070a8e5188",
-                "reference": "bd60fbb12c456415a344e041e82161070a8e5188",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/5ef9f68ec6854d001dc37a08feed28297357673b",
+                "reference": "5ef9f68ec6854d001dc37a08feed28297357673b",
                 "shasum": ""
             },
             "require": {
@@ -4077,10 +4077,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/4.0.5",
+                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/4.0.6",
                 "issues": "https://github.com/City-of-Helsinki/drupal-hdbt/issues"
             },
-            "time": "2022-10-05T12:00:20+00:00"
+            "time": "2022-10-06T15:20:33+00:00"
         },
         {
             "name": "drupal/hdbt_admin",


### PR DESCRIPTION
# [UHF-6829](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6829)
<!-- What problem does this solve? -->
Removes dropdown indicator where children are not enabled or unpublished.
## What was done
<!-- Describe what was done -->

* Updated hdbt.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6829-dropdown-indicator`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the dropdown indicator is not present when not needed.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
