### PR TITLE
UHF-6955: Added chat to new pages

### DIFF
--- a/conf/cmi/block.block.chatleijuke.yml
+++ b/conf/cmi/block.block.chatleijuke.yml
@@ -24,4 +24,4 @@ visibility:
   request_path:
     id: request_path
     negate: false
-    pages: "/neuvonta-ja-tuki/helsinki-info\r\n/informationstjanster-och-stod/helsingfors-info\r\n/advisory-and-support-services/helsinki-info\r\n/neuvonta-ja-tuki/helsinki-info/*\r\n/informationstjanster-och-stod/helsingfors-info/*\r\n/advisory-and-support-services/helsinki-info/*\r\n/ota-yhteytta/helsinki-info\r\n/ta-kontakt/helsingfors-info\r\n/contact-us/helsinki-info"
+    pages: "/neuvonta-ja-tuki/helsinki-info\r\n/informationstjanster-och-stod/helsingfors-info\r\n/advisory-and-support-services/helsinki-info\r\n/neuvonta-ja-tuki/helsinki-info/*\r\n/informationstjanster-och-stod/helsingfors-info/*\r\n/advisory-and-support-services/helsinki-info/*\r\n/ota-yhteytta/helsinki-info\r\n/ta-kontakt/helsingfors-info\r\n/contact-us/helsinki-info\r\n/ota-yhteytta-helsingin-kaupunkiin\r\n/kontakta-helsingfors-stad\r\n/contact-the-city-of-helsinki"


### PR DESCRIPTION
# Chat to new pages [UHF-6955](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6955)

Added chat to new pages

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
* Go to /admin/structure/block/manage/chatleijuke
  * Go to pages-tab
You should see 3 new links on the whitelist (/ota-yhteytta-helsingin-kaupunkiin + it's translations)

