### PR TITLE
UHF-7739: set cache max 1 day

### DIFF
--- a/conf/cmi/external_entities.external_entity_type.helfi_news.yml
+++ b/conf/cmi/external_entities.external_entity_type.helfi_news.yml
@@ -34,8 +34,8 @@ field_mapper_config:
     short_title:
       value: '$.attributes[''short_title'']'
 storage_client_id: helfi_news
-storage_client_config: {  }
-persistent_cache_max_age: -1
+storage_client_config: null
+persistent_cache_max_age: 86400
 annotation_entity_type_id: null
 annotation_bundle_id: null
 annotation_field_name: null

--- a/conf/cmi/external_entities.external_entity_type.helfi_news_groups.yml
+++ b/conf/cmi/external_entities.external_entity_type.helfi_news_groups.yml
@@ -19,8 +19,8 @@ field_mapper_config:
     title:
       value: '$.attributes["name"]'
 storage_client_id: helfi_news_groups
-storage_client_config: {  }
-persistent_cache_max_age: -1
+storage_client_config: null
+persistent_cache_max_age: 86400
 annotation_entity_type_id: null
 annotation_bundle_id: null
 annotation_field_name: null

--- a/conf/cmi/external_entities.external_entity_type.helfi_news_neighbourhoods.yml
+++ b/conf/cmi/external_entities.external_entity_type.helfi_news_neighbourhoods.yml
@@ -19,8 +19,8 @@ field_mapper_config:
     title:
       value: '$.attributes["name"]'
 storage_client_id: helfi_news_neighbourhoods
-storage_client_config: {  }
-persistent_cache_max_age: -1
+storage_client_config: null
+persistent_cache_max_age: 86400
 annotation_entity_type_id: null
 annotation_bundle_id: null
 annotation_field_name: null

--- a/conf/cmi/external_entities.external_entity_type.helfi_news_tags.yml
+++ b/conf/cmi/external_entities.external_entity_type.helfi_news_tags.yml
@@ -19,8 +19,8 @@ field_mapper_config:
     title:
       value: '$.attributes["name"]'
 storage_client_id: helfi_news_tags
-storage_client_config: {  }
-persistent_cache_max_age: -1
+storage_client_config: null
+persistent_cache_max_age: 86400
 annotation_entity_type_id: null
 annotation_bundle_id: null
 annotation_field_name: null


### PR DESCRIPTION
# [UHF-7739](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7739)
Set external entity cache for news related entities to invalidate after 1 day

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7739_news_feed_update`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Trying to figure it out



[UHF-7739]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ