### PR TITLE
Update platform config manually.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4505,16 +4505,16 @@
         },
         {
             "name": "drupal/helfi_platform_config",
-            "version": "2.17.5",
+            "version": "2.17.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config.git",
-                "reference": "965bda197229bd80b085909c01b11da071f0460d"
+                "reference": "f3572529c1f2b2f9f0fb82d708ce55a29d04f93f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/965bda197229bd80b085909c01b11da071f0460d",
-                "reference": "965bda197229bd80b085909c01b11da071f0460d",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/f3572529c1f2b2f9f0fb82d708ce55a29d04f93f",
+                "reference": "f3572529c1f2b2f9f0fb82d708ce55a29d04f93f",
                 "shasum": ""
             },
             "require": {
@@ -4626,10 +4626,10 @@
             ],
             "description": "HELfi platform config",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.17.5",
+                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.17.6",
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
-            "time": "2023-02-14T06:06:13+00:00"
+            "time": "2023-02-15T07:24:23+00:00"
         },
         {
             "name": "drupal/helfi_proxy",


### PR DESCRIPTION
Platform config release 2.17.6 was missing due to errors in the automatic workflows, this adds it. No config changes or database updates.