### PR TITLE
UHF-8238: Disable old TALPA embed, add new version.

### DIFF
--- a/conf/cmi/block.block.chatleijuke_talpa_watson.yml
+++ b/conf/cmi/block.block.chatleijuke_talpa_watson.yml
@@ -1,6 +1,6 @@
 uuid: 79f78b82-b303-47dc-962d-a21e4ad10a39
 langcode: fi
-status: true
+status: false
 dependencies:
   module:
     - helfi_platform_config

--- a/conf/cmi/block.block.ibmchatapp_watson_talpa.yml
+++ b/conf/cmi/block.block.ibmchatapp_watson_talpa.yml
@@ -1,0 +1,29 @@
+uuid: c786bc09-2e9a-4ef9-8b51-c1dab7262461
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_platform_config
+    - system
+  theme:
+    - hdbt
+id: ibmchatapp_watson_talpa
+theme: hdbt
+region: attachments
+weight: 0
+provider: null
+plugin: ibm_chat_app
+settings:
+  id: ibm_chat_app
+  label: 'IBM Chat App Watson - TALPA'
+  label_display: '0'
+  provider: helfi_platform_config
+  hostname: 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
+  engagementId: talpa
+  tenantId: 'www-hel-fi- prod'
+  assistantId: talpa
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: "/ota-yhteytta/kaupungin-laskut-ja-maksut\r\n/ota-yhteytta/kaupungin-laskut-ja-maksut/kaupungille-osoitetut-laskut"

--- a/conf/cmi/block.block.ibmchatapp_watson_talpa.yml
+++ b/conf/cmi/block.block.ibmchatapp_watson_talpa.yml
@@ -20,7 +20,7 @@ settings:
   provider: helfi_platform_config
   hostname: 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
   engagementId: talpa
-  tenantId: 'www-hel-fi- prod'
+  tenantId: 'www-hel-fi-prod'
   assistantId: talpa
 visibility:
   request_path:


### PR DESCRIPTION
# [UHF-8238](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8238)

## What was done
This PR disables old IBM Watson chatbot embeds and enables the new one.

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8238-new-ibm-chatbots`
  * `make fresh`
* Run `make drush-cr`

## How to test
* [ ] Check that this feature works
  * Can't be fully tested yet because the applications need to be updated on IBM's side first
* [ ] Compare the [new block config](https://strategia.docker.so/fi/paatoksenteko-ja-hallinto/admin/structure/block) to the disabled "ChatLeijuke" blocks and the Platform config libraries file: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/blob/3.x/helfi_platform_config.libraries.yml
  * The pages the block appears on should be the same
  * The tentantID and assistandID parameters should be the same  
* [ ] Check that code follows our standards
  * Check the YML files and make sure there's nothing weird there

## Designers review
* [x] This PR does not need designers review

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/550
* https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/222


[UHF-8238]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ