### PR TITLE
UHF-8716:  Enable Askem (React & Share) to service pages

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - helfi_platform_config
     - node
+    - system
   theme:
     - hdbt_subtheme
 _core:
@@ -21,11 +22,7 @@ settings:
   label_display: '0'
   provider: helfi_platform_config
 visibility:
-  'entity_bundle:node':
-    id: 'entity_bundle:node'
+  request_path:
+    id: request_path
     negate: true
-    context_mapping:
-      node: '@node.node_route_context:node'
-    bundles:
-      announcement: announcement
-      news_item: news_item
+    pages: "/news/*\r\n/uutiset/*\r\n/nyheter/*"


### PR DESCRIPTION
# [UHF-8716](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8716)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Limited the Askem (React & Share) block to be hidden only on news pages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8716_enable_askem_to_service_pages`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the Askem (React & Share) block is now visible on TPR Service and TPR Unit where it wasn't visible before.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/688
* https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/490


[UHF-8716]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ