### PR TITLE
UHF-X: Unify strategia project url structure on local to same as other local instances

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 #
 
 # Docker Compose project name
-COMPOSE_PROJECT_NAME=strategia
+COMPOSE_PROJECT_NAME=helfi-strategia
 PROJECT_NAME=strategia
 
 # OpenShift project name
@@ -13,7 +13,7 @@ STAGE_FILE_PROXY_ORIGIN=https://stplattaprod.blob.core.windows.net
 STAGE_FILE_PROXY_ORIGIN_DIR=strategiatalousprod
 
 # Local hostname
-DRUPAL_HOSTNAME=strategia.docker.so
+DRUPAL_HOSTNAME=helfi-strategia.docker.so
 
 # Docker image
 DRUPAL_IMAGE=ghcr.io/city-of-helsinki/drupal-web:8.3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Helsinki.
 
 Env | Branch | Drush alias | URL
 --- | ------ | ----------- | ---
-development | * | - | http://strategia.docker.so/
+development | * | - | http://helfi-strategia.docker.so/
 production | main | @main | https://hel.fi/fi/paatoksenteko-ja-hallinto
 
 ## Requirements


### PR DESCRIPTION
# UHF-X: Unify strategia project url structure on local to same as other local instances
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed the local url format to helfi-strategia.docker.so from just strategia.docker.so

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_unify_local_url_structure`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure your local site is now found from https://helfi-strategia.docker.so/ (this also fixes issue with global mobile navigation not working on local in this instance)
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Other pull requests

* https://github.com/City-of-Helsinki/drupal-helfi-local-proxy/pull/2
* https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/670