### PR TITLE
UHF-X: Breadcrumb home segment fix

### DIFF
--- a/conf/cmi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/easy_breadcrumb.settings.yml
@@ -6,7 +6,7 @@ replaced_titles: ''
 custom_paths: ''
 include_home_segment: true
 alternative_title_field: ''
-home_segment_title: Decision
+home_segment_title: 'Decision-making'
 home_segment_keep: false
 include_title_segment: true
 title_from_page_when_available: true


### PR DESCRIPTION
# UHF-X: Breadcrumb home segment fix
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change the breadcrumb home segment to correct in English.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_decision_making_breadcrumb_setting_change`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the home segment on breadcrumbs is now always "Decision-making" instead of the old "Decision".
* [ ] Check that code follows our standards.
